### PR TITLE
Fix/webpack dev server

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,17 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"
+RUN su node -c "npm install -g depcheck typescript"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,52 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 12, 14, 16
+		"args": {
+			"VARIANT": "16"
+		}
+	},
+	// Set the CHOKIDAR_USEPOLLING to true to enable polling for changes
+	// of files and subsequent automatic to recompilation.
+	// See: https://stackoverflow.com/a/44643246/1288109
+	"containerEnv": {
+		"CHOKIDAR_USEPOLLING": "true"
+	},
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"terminal.integrated.defaultProfile.linux": "zsh",
+		"terminal.integrated.profiles.linux": {
+			"bash": {
+				"path": "/usr/bin/flatpak-spawn",
+				"args": [
+					"--host",
+					"--env=TERM=xterm-256color",
+					"bash"
+				]
+			}
+		}
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint",
+		"eamodio.gitlens"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [3000],
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+	
+	// See: https://code.visualstudio.com/docs/remote/containers-advanced
+	"mounts": [
+		"source=react-mapbox-gl-draw-node_modules,target=${containerWorkspaceFolder}/node_modules,type=volume"
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "sudo chown node ${containerWorkspaceFolder}/node_modules && git config --global oh-my-zsh.hide-info 1 && git config --global oh-my-zsh.hide-status 1 && git config --global oh-my-zsh.hide-dirty 1"
+}

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import ReactMapboxGl from 'react-mapbox-gl';
+import 'mapbox-gl/dist/mapbox-gl.css';
 import '@mapbox/mapbox-gl-draw/dist/mapbox-gl-draw.css';
 
 import DrawControl from '../../lib';

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -14,9 +14,9 @@ module.exports = {
       }
     ]
   },
-  node: {
-    fs: 'empty' // https://github.com/mapbox/mapbox-gl-draw/issues/626
-  },
+  // node: {
+  //   fs: 'empty' // https://github.com/mapbox/mapbox-gl-draw/issues/626
+  // },
   resolve: {
     extensions: ['*', '.js', '.jsx']
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 		"prebuild": "rimraf lib/",
 		"build": "tsc",
 		"deploy": "yarn build && standard-version",
-		"example": "yarn build && cd example && webpack-dev-server",
+		"example": "yarn build && cd example && webpack serve",
 		"lint": "tsc --noEmit && eslint . --ext ts",
 		"test": "echo skipped for now."
 	},


### PR DESCRIPTION
Fix issue with webpack-dev-server (now deprecated)
Add missing import of css that causes error in controls display
Removed "fs: 'empty'" configuration; warning: this line was marked with a reference to an issue
Add support to in-container development with VSCode and Docker. To run the example within VSCode: just open the project's directory in container, then in a terminal, run "yarn", then "yarn example"; view the result in a browser at www://localhost:8080